### PR TITLE
feature: add option to deploy standalone prometheus workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,10 @@ No resources.
 | <a name="input_logical_product_family"></a> [logical\_product\_family](#input\_logical\_product\_family) | (Required) Name of the product family for which the resource is created.<br>    Example: org\_name, department\_name. | `string` | `"launch"` | no |
 | <a name="input_logical_product_service"></a> [logical\_product\_service](#input\_logical\_product\_service) | (Required) Name of the product service for which the resource is created.<br>    For example, backend, frontend, middleware etc. | `string` | `"redis"` | no |
 | <a name="input_class_env"></a> [class\_env](#input\_class\_env) | (Required) Environment where resource is going to be deployed. For example. dev, qa, uat | `string` | `"dev"` | no |
-| <a name="input_grafana_name"></a> [grafana\_name](#input\_grafana\_name) | Name of the managed grafana instance | `string` | n/a | yes |
+| <a name="input_grafana_name"></a> [grafana\_name](#input\_grafana\_name) | Name of the managed grafana instance | `string` | `null` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | name of the resource group where the managed grafana instance will be created | `string` | `null` | no |
 | <a name="input_location"></a> [location](#input\_location) | Location where the managed grafana instance will be created | `string` | `"eastus"` | no |
+| <a name="input_grafana_enabled"></a> [grafana\_enabled](#input\_grafana\_enabled) | Whether to deploy a managed grafana instance with the workspace | `bool` | `true` | no |
 | <a name="input_grafana_api_key_enabled"></a> [grafana\_api\_key\_enabled](#input\_grafana\_api\_key\_enabled) | Whether to enable API keys for the managed grafana instance. Defaults to false | `bool` | `false` | no |
 | <a name="input_grafana_deterministic_outbound_ip_enabled"></a> [grafana\_deterministic\_outbound\_ip\_enabled](#input\_grafana\_deterministic\_outbound\_ip\_enabled) | Whether to enable deterministic outbound IP for the managed grafana instance. Defaults to false | `bool` | `false` | no |
 | <a name="input_grafana_major_version"></a> [grafana\_major\_version](#input\_grafana\_major\_version) | Major version of Grafana to deploy | `string` | `"10"` | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -33,7 +33,8 @@ No resources.
 | <a name="input_logical_product_service"></a> [logical\_product\_service](#input\_logical\_product\_service) | (Required) Name of the product service for which the resource is created.<br>    For example, backend, frontend, middleware etc. | `string` | `"redis"` | no |
 | <a name="input_class_env"></a> [class\_env](#input\_class\_env) | (Required) Environment where resource is going to be deployed. For example. dev, qa, uat | `string` | `"dev"` | no |
 | <a name="input_location"></a> [location](#input\_location) | Location where the managed grafana instance will be created | `string` | `"eastus"` | no |
-| <a name="input_grafana_name"></a> [grafana\_name](#input\_grafana\_name) | Name of the managed grafana instance | `string` | n/a | yes |
+| <a name="input_grafana_enabled"></a> [grafana\_enabled](#input\_grafana\_enabled) | Whether to deploy a managed grafana instance with the workspace | `bool` | `true` | no |
+| <a name="input_grafana_name"></a> [grafana\_name](#input\_grafana\_name) | Name of the managed grafana instance | `string` | `null` | no |
 | <a name="input_grafana_api_key_enabled"></a> [grafana\_api\_key\_enabled](#input\_grafana\_api\_key\_enabled) | Whether to enable API keys for the managed grafana instance. Defaults to false | `bool` | `false` | no |
 | <a name="input_grafana_deterministic_outbound_ip_enabled"></a> [grafana\_deterministic\_outbound\_ip\_enabled](#input\_grafana\_deterministic\_outbound\_ip\_enabled) | Whether to enable deterministic outbound IP for the managed grafana instance. Defaults to false | `bool` | `false` | no |
 | <a name="input_grafana_major_version"></a> [grafana\_major\_version](#input\_grafana\_major\_version) | Major version of Grafana to deploy | `string` | `"10"` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -22,6 +22,7 @@ module "grafana_workspace" {
   logical_product_service = var.logical_product_service
 
   grafana_name                              = var.grafana_name
+  grafana_enabled                           = var.grafana_enabled
   grafana_api_key_enabled                   = var.grafana_api_key_enabled
   grafana_deterministic_outbound_ip_enabled = var.grafana_deterministic_outbound_ip_enabled
   grafana_zone_redundancy_enabled           = var.grafana_zone_redundancy_enabled

--- a/examples/complete/test.tfvars
+++ b/examples/complete/test.tfvars
@@ -5,4 +5,5 @@ logical_product_service = "grafana"
 class_env               = "gotest"
 location                = "eastus"
 
-grafana_name = "launchgotestgrafana000"
+grafana_name    = "launchgotestgrafana000"
+grafana_enabled = false

--- a/examples/complete/test.tfvars
+++ b/examples/complete/test.tfvars
@@ -5,5 +5,4 @@ logical_product_service = "grafana"
 class_env               = "gotest"
 location                = "eastus"
 
-grafana_name    = "launchgotestgrafana000"
-grafana_enabled = false
+grafana_name = "launchgotestgrafana000"

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -107,9 +107,16 @@ variable "location" {
   default     = "eastus"
 }
 
+variable "grafana_enabled" {
+  description = "Whether to deploy a managed grafana instance with the workspace"
+  type        = bool
+  default     = true
+}
+
 variable "grafana_name" {
   description = "Name of the managed grafana instance"
   type        = string
+  default     = null
 
   validation {
     condition     = can(regex("^[a-z][a-z0-9-]+[a-z0-9]$", var.grafana_name))

--- a/locals.tf
+++ b/locals.tf
@@ -16,6 +16,6 @@ locals {
   }
   tags = merge(local.default_tags, var.tags)
 
-  grafana_name        = var.grafana_name != null ? var.grafana_name : var.resource_names_map["grafana"].minimal_random_suffix_without_any_separators
+  grafana_name        = var.grafana_name != null ? var.grafana_name : module.resource_names["grafana"].minimal_random_suffix_without_any_separators
   resource_group_name = var.resource_group_name != null ? var.resource_group_name : module.resource_group[0].name
 }

--- a/main.tf
+++ b/main.tf
@@ -58,6 +58,8 @@ module "grafana" {
   source  = "terraform.registry.launch.nttdata.com/module_primitive/grafana/azurerm"
   version = "~> 1.0"
 
+  count = var.grafana_enabled ? 1 : 0
+
   name                = local.grafana_name
   resource_group_name = local.resource_group_name
   location            = var.location

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,27 +12,27 @@
 
 output "grafana_id" {
   description = "Resource ID of the managed grafana instance"
-  value       = module.grafana.id
+  value       = length(module.grafana) > 0 ? module.grafana[0].id : null
 }
 
 output "grafana_name" {
   description = "Name of the managed grafana instance"
-  value       = module.grafana.name
+  value       = length(module.grafana) > 0 ? module.grafana[0].name : null
 }
 
 output "grafana_endpoint" {
   description = "Name of the managed grafana instance"
-  value       = try(module.grafana.endpoint, null)
+  value       = length(module.grafana) > 0 ? module.grafana[0].endpoint : null
 }
 
 output "grafana_outbound_ip" {
   description = "Outbound IP of the managed grafana instance if `deterministic_outbound_ip_enabled` is true"
-  value       = try(module.grafana.outbound_ip, null)
+  value       = length(module.grafana) > 0 ? module.grafana[0].outbound_ip : null
 }
 
 output "grafana_principal_id" {
   description = "Principal ID of the managed grafana instance"
-  value       = module.grafana.principal_id
+  value       = length(module.grafana) > 0 ? module.grafana[0].principal_id : null
 }
 
 output "monitor_workspace_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -104,6 +104,7 @@ variable "class_env" {
 variable "grafana_name" {
   description = "Name of the managed grafana instance"
   type        = string
+  default     = null
 
   validation {
     condition     = can(regex("^[a-z][a-z0-9-]+[a-z0-9]$", var.grafana_name))
@@ -126,6 +127,12 @@ variable "location" {
   description = "Location where the managed grafana instance will be created"
   type        = string
   default     = "eastus"
+}
+
+variable "grafana_enabled" {
+  description = "Whether to deploy a managed grafana instance with the workspace"
+  type        = bool
+  default     = true
 }
 
 variable "grafana_api_key_enabled" {


### PR DESCRIPTION
Add option to deploy a standalone Prometheus datasource to be used by a grafana instance not in this module